### PR TITLE
Obtain task outputs from AWS logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.36.0] - 2023-06-20
 
+### Added
+
+- Output stream and exceptions support for AWSBatchExecutor.
+
+- A necessary `cache_dir` argument (in lieu of `**kwargs`, removed by previous).
+
 ### Changed
 
 - Updates __init__ signature kwargs replaced with parent for better documentation.


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Increment the version number in the /VERSION file. If this is a bugfix, increment the patch version (the rightmost number), for example 0.18.2 becomes 0.18.3. If it's a new feature, increment the minor version (the middle number), for example 0.18.2 becomes 0.19.0. 
⚠️ Add a note to /CHANGELOG.md with your version number and the date, summarizing the changes.
⚠️ If your pull request fixes an open issue, please link to the issue.
⚠️ Rebase the latest changes from the develop branch. Assuming origin points to https://github.com/AgnostiqHQ/covalent, you should run git rebase origin/develop.
-->

## Issue
Fixes: https://github.com/AgnostiqHQ/covalent-awsbatch-plugin/issues/53

## Important Notes
**This PR requires the following additional changes.**

1. https://github.com/AgnostiqHQ/covalent-aws-plugins/pull/44.
2. https://github.com/AgnostiqHQ/covalent/pull/1764.

Additionally, 
- If we go ahead with this fix, the default Batch container image will need to be updated, for both QElectrons and `exec.py` changes.
- For QElectrons, the container will need `covalent[qiskit,braket]`, with extras. This made `g++` a build dependency for me, but maybe that's just me.

## Extras

### Example Dockerfile for AWSBatch

The one tar file contains the [`qelectron` branch](https://github.com/AgnostiqHQ/covalent/tree/qelectron) from the public covalent repo.

The execution script `exec.py` is shown in the example after this one.

```dockerfile
FROM python:3.8-slim-bullseye

ENV COVALENT_PKG="covalent-qelectron.tar.gz" 

WORKDIR /covalent


RUN apt-get update \
  && apt-get install -y --no-install-recommends rsync g++ \
  && rm -rf /var/lib/apt/lists/*

COPY ${COVALENT_PKG} /covalent/${COVALENT_PKG}

RUN pip install --upgrade pip \
  && pip install --upgrade setuptools \
  && pip install boto3 \
  && pip install /covalent/${COVALENT_PKG}[qiskit,braket] \
  && rm /covalent/${COVALENT_PKG} \
  && rm -rf /root/.cache/pip

RUN apt-get purge -y g++ && \
  apt-get autoremove -y && \
  apt-get clean -y

COPY exec.py /covalent/exec.py

ENTRYPOINT [ "python" ]
CMD [ "/covalent/exec.py" ]
```

### Example `exec.py`

The change here corresponds to this PR: https://github.com/AgnostiqHQ/covalent-aws-plugins/pull/44

The main point of this is using that `_TeeStream` class to "`tee`" (or multiplex?) stdout/stderr into local files. We then upload those files.

Exceptions are caught and also included in the upload. All exceptions are then re-raised. Results are only uploaded if there is no exception.

```python
import contextlib
import os
import sys
import traceback

import boto3
import cloudpickle as pickle


s3_bucket = os.environ["S3_BUCKET_NAME"]
if not s3_bucket:
    raise ValueError("Environment variable S3_BUCKET_NAME was not found")

func_filename = os.environ["COVALENT_TASK_FUNC_FILENAME"]
if not func_filename:
    raise ValueError("Environment variable FUNC_FILENAME was not found")

result_filename = os.environ["RESULT_FILENAME"]
if not result_filename:
    raise ValueError("Environment variable RESULT_FILENAME was not found")

output_filename = result_filename.replace("result", "output")

# Create files for function, result, and outputs.
local_func_filename = os.path.join("/covalent", func_filename)
local_result_filename = os.path.join("/covalent", result_filename)
local_outputs_filename = os.path.join("/covalent", output_filename)

# Load task function.
s3 = boto3.client("s3")
s3.download_file(s3_bucket, func_filename, local_func_filename)

with open(local_func_filename, "rb") as f:
    function, args, kwargs = pickle.load(f)


class _TeeStream:

    # Used for tee-ing stdout/stderr with file streams.

    def __init__(self, *streams):
        self.streams = streams

    def write(self, data):
        for stream in self.streams:
            stream.write(data)
            stream.flush()

    def flush(self):
        for stream in self.streams:
            stream.flush()


# Create tee streams to copy stdout/stderr to local files.
stdout_log = os.path.join("/covalent", "stdout.log")
stderr_log = os.path.join("/covalent", "stderr.log")
stdout_tee = _TeeStream(sys.stdout, open(stdout_log, "w", encoding="utf-8"))
stderr_tee = _TeeStream(sys.stderr, open(stderr_log, "w", encoding="utf-8"))

result = None
task_exception = None
traceback_str = None
exception_cls = None

# Redirect stdout/stderr to tee streams.
with contextlib.redirect_stdout(stdout_tee), contextlib.redirect_stderr(stderr_tee):
    try:
        # RUN TASK FUNCTION
        result = function(*args, **kwargs)

    except Exception as exception:
        # Collect error information.
        task_exception = exception
        traceback_str = traceback.format_exc()
        exception_cls = type(exception)

    finally:
        # Close the log file streams.
        stdout_tee.streams[1].close()
        stderr_tee.streams[1].close()

# Create the local outputs file.
with open(local_outputs_filename, "wb") as f, \
        open(stdout_log, "r", encoding="utf-8") as f_out, \
        open(stderr_log, "r", encoding="utf-8") as f_err:

    stdout = f_out.read()
    stderr = f_err.read()
    pickle.dump((stdout, stderr, traceback_str, exception_cls), f)

# Upload the local outputs file.
s3.upload_file(local_outputs_filename, s3_bucket, output_filename)

if task_exception is not None:
    raise task_exception

# Create the local result file.
with open(local_result_filename, "wb") as f:
    pickle.dump(result, f)

# Upload the local result file.
s3.upload_file(local_result_filename, s3_bucket, result_filename)

```

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.
