### PR TITLE
version change for aws provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated the provider version for AWS to 5.17.0
+- Updated the terraform provider version for AWS to 5.17.0 (batch plugin)
 
 ## [0.38.0] - 2023-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Updated the provider version for AWS to 5.17.0
+
 ## [0.38.0] - 2023-09-20
 
 ### Changed

--- a/covalent_awsbatch_plugin/assets/infra/versions.tf
+++ b/covalent_awsbatch_plugin/assets/infra/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.23"
+      version = "5.17.0"
     }
   }
 }


### PR DESCRIPTION
Changed:
- Updated the terraform provider version for AWS to 5.17.0 (batch plugin)
