### PR TITLE
Require no variables to covalent deploy awsbatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Edit terraform scripts to require no user input in most cases (maybe `region`).
+
 ## [0.41.2] - 2023-11-06
 
 ### Fixed

--- a/covalent_awsbatch_plugin/assets/infra/iam.tf
+++ b/covalent_awsbatch_plugin/assets/infra/iam.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 }
 
 resource "aws_iam_role" "ecs_tasks_execution_role" {
-  name               = "task-execution-role-${local.suffix}"
+  name               = "task-execution-role-${local.prefix}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 
@@ -41,12 +41,12 @@ resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
 }
 
 resource "aws_iam_instance_profile" "ecs_instance_role" {
-  name = "instance-profile-${local.suffix}"
+  name = "instance-profile-${local.prefix}"
   role = aws_iam_role.ecs_instance_role.name
 }
 
 resource "aws_iam_role" "ecs_instance_role" {
-  name = "instance-role-${local.suffix}"
+  name = "instance-role-${local.prefix}"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -63,7 +63,7 @@ resource "aws_iam_role" "ecs_instance_role" {
 }
 
 resource "aws_iam_role" "aws_batch_service_role" {
-  name = "service-role-${local.suffix}"
+  name = "service-role-${local.prefix}"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -85,7 +85,7 @@ resource "aws_iam_role_policy_attachment" "aws_batch_service_role_attachment" {
 }
 
 resource "aws_iam_role_policy" "job_policy" {
-  name = "job-policy-${local.suffix}"
+  name = "job-policy-${local.prefix}"
   role = aws_iam_role.job_role.id
 
   policy = jsonencode({
@@ -150,7 +150,7 @@ resource "aws_iam_role_policy" "job_policy" {
 }
 
 resource "aws_iam_role" "job_role" {
-  name = "job-role-${local.suffix}"
+  name = "job-role-${local.prefix}"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",

--- a/covalent_awsbatch_plugin/assets/infra/iam.tf
+++ b/covalent_awsbatch_plugin/assets/infra/iam.tf
@@ -1,3 +1,19 @@
+# Copyright 2021 Agnostiq Inc.
+#
+# This file is part of Covalent.
+#
+# Licensed under the Apache License 2.0 (the "License"). A copy of the
+# License may be obtained with this software package or at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Use of this file is prohibited except in compliance with the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 data "aws_iam_policy_document" "assume_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]

--- a/covalent_awsbatch_plugin/assets/infra/iam.tf
+++ b/covalent_awsbatch_plugin/assets/infra/iam.tf
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+data "aws_caller_identity" "current" {}
+
 data "aws_iam_policy_document" "assume_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]

--- a/covalent_awsbatch_plugin/assets/infra/iam.tf
+++ b/covalent_awsbatch_plugin/assets/infra/iam.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 }
 
 resource "aws_iam_role" "ecs_tasks_execution_role" {
-  name               = "task-execution-role-${local.prefix}"
+  name               = "covalent-${local.prefix}-task-execution-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 
@@ -43,12 +43,12 @@ resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
 }
 
 resource "aws_iam_instance_profile" "ecs_instance_role" {
-  name = "instance-profile-${local.prefix}"
+  name = "covalent-${local.prefix}-instance-profile"
   role = aws_iam_role.ecs_instance_role.name
 }
 
 resource "aws_iam_role" "ecs_instance_role" {
-  name = "instance-role-${local.prefix}"
+  name = "covalent-${local.prefix}-instance-role"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -65,7 +65,7 @@ resource "aws_iam_role" "ecs_instance_role" {
 }
 
 resource "aws_iam_role" "aws_batch_service_role" {
-  name = "service-role-${local.prefix}"
+  name = "covalent-${local.prefix}-service-role"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -87,7 +87,7 @@ resource "aws_iam_role_policy_attachment" "aws_batch_service_role_attachment" {
 }
 
 resource "aws_iam_role_policy" "job_policy" {
-  name = "job-policy-${local.prefix}"
+  name = "covalent-${local.prefix}-job-policy"
   role = aws_iam_role.job_role.id
 
   policy = jsonencode({
@@ -152,7 +152,7 @@ resource "aws_iam_role_policy" "job_policy" {
 }
 
 resource "aws_iam_role" "job_role" {
-  name = "job-role-${local.prefix}"
+  name = "covalent-${local.prefix}-job-role"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",

--- a/covalent_awsbatch_plugin/assets/infra/iam.tf
+++ b/covalent_awsbatch_plugin/assets/infra/iam.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 }
 
 resource "aws_iam_role" "ecs_tasks_execution_role" {
-  name               = "${var.prefix}-task-execution-role"
+  name               = "task-execution-role-${local.suffix}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 
@@ -25,13 +25,12 @@ resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
 }
 
 resource "aws_iam_instance_profile" "ecs_instance_role" {
-  name = "${var.prefix}-instance-profile"
+  name = "instance-profile-${local.suffix}"
   role = aws_iam_role.ecs_instance_role.name
 }
 
-
 resource "aws_iam_role" "ecs_instance_role" {
-  name = "${var.prefix}-instance-role"
+  name = "instance-role-${local.suffix}"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -48,7 +47,7 @@ resource "aws_iam_role" "ecs_instance_role" {
 }
 
 resource "aws_iam_role" "aws_batch_service_role" {
-  name = "${var.prefix}-service-role"
+  name = "service-role-${local.suffix}"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -70,7 +69,7 @@ resource "aws_iam_role_policy_attachment" "aws_batch_service_role_attachment" {
 }
 
 resource "aws_iam_role_policy" "job_policy" {
-  name = "${var.prefix}-job-policy"
+  name = "job-policy-${local.suffix}"
   role = aws_iam_role.job_role.id
 
   policy = jsonencode({
@@ -135,7 +134,7 @@ resource "aws_iam_role_policy" "job_policy" {
 }
 
 resource "aws_iam_role" "job_role" {
-  name = "${var.prefix}-job-role"
+  name = "job-role-${local.suffix}"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",

--- a/covalent_awsbatch_plugin/assets/infra/main.tf
+++ b/covalent_awsbatch_plugin/assets/infra/main.tf
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "aws_caller_identity" "current" {}
-
 provider "aws" {
   region = var.aws_region
 }

--- a/covalent_awsbatch_plugin/assets/infra/main.tf
+++ b/covalent_awsbatch_plugin/assets/infra/main.tf
@@ -20,14 +20,14 @@ provider "aws" {
   region = var.aws_region
 }
 
-resource "random_string" "default_suffix" {
+resource "random_string" "default_prefix" {
   length  = 9
   upper   = false
   special = false
 }
 
 locals {
-  suffix    = var.suffix == "" ? random_string.default_suffix.result : var.suffix
+  prefix    = var.prefix == "" ? random_string.default_prefix.result : var.prefix
   vpc_id    = var.vpc_id == "" ? aws_default_vpc.default.id : var.vpc_id
   subnet_id = var.subnet_id == "" ? aws_default_subnet.default.id : var.subnet_id
 }
@@ -38,7 +38,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_batch_compute_environment" "compute_environment" {
-  compute_environment_name = "compute-environment-${local.suffix}"
+  compute_environment_name = "compute-environment-${local.prefix}"
 
   compute_resources {
     instance_role = aws_iam_instance_profile.ecs_instance_role.arn
@@ -58,7 +58,7 @@ resource "aws_batch_compute_environment" "compute_environment" {
   depends_on   = [aws_iam_role_policy_attachment.aws_batch_service_role_attachment]
 }
 resource "aws_batch_job_queue" "job_queue" {
-  name     = "queue-${local.suffix}"
+  name     = "queue-${local.prefix}"
   state    = "ENABLED"
   priority = 1
 
@@ -68,11 +68,11 @@ resource "aws_batch_job_queue" "job_queue" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  name = "log-group-${local.suffix}"
+  name = "log-group-${local.prefix}"
 }
 
 resource "aws_cloudwatch_log_stream" "log_stream" {
-  name           = "log-stream-${local.suffix}"
+  name           = "log-stream-${local.prefix}"
   log_group_name = aws_cloudwatch_log_group.log_group.name
 }
 

--- a/covalent_awsbatch_plugin/assets/infra/main.tf
+++ b/covalent_awsbatch_plugin/assets/infra/main.tf
@@ -30,6 +30,8 @@ locals {
   prefix    = var.prefix == "" ? random_string.default_prefix.result : var.prefix
   vpc_id    = var.vpc_id == "" ? aws_default_vpc.default.id : var.vpc_id
   subnet_id = var.subnet_id == "" ? aws_default_subnet.default.id : var.subnet_id
+  credentials = var.credentials == "" ? pathexpand("~/.aws/credentials") : var.credentials
+  profile = var.profile == "" ? "default" : var.profile
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -81,8 +83,8 @@ resource "aws_cloudwatch_log_stream" "log_stream" {
 resource "local_file" "rest_api_openapi_spec" {
   filename = "${path.module}/awsbatch.conf"
   content = templatefile("${path.module}/awsbatch.conf.tftpl", {
-    credentials               = var.credentials
-    profile                   = var.profile
+    credentials               = local.credentials
+    profile                   = local.profile
     region                    = var.aws_region
     s3_bucket_name            = aws_s3_bucket.bucket.id
     batch_queue               = aws_batch_job_queue.job_queue.name

--- a/covalent_awsbatch_plugin/assets/infra/main.tf
+++ b/covalent_awsbatch_plugin/assets/infra/main.tf
@@ -39,7 +39,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_batch_compute_environment" "compute_environment" {
-  compute_environment_name = "compute-environment-${local.prefix}"
+  compute_environment_name = "covalent-${local.prefix}-compute-environment"
 
   compute_resources {
     instance_role = aws_iam_instance_profile.ecs_instance_role.arn
@@ -59,7 +59,7 @@ resource "aws_batch_compute_environment" "compute_environment" {
   depends_on   = [aws_iam_role_policy_attachment.aws_batch_service_role_attachment]
 }
 resource "aws_batch_job_queue" "job_queue" {
-  name     = "queue-${local.prefix}"
+  name     = "covalent-${local.prefix}-job-queue"
   state    = "ENABLED"
   priority = 1
 
@@ -69,11 +69,11 @@ resource "aws_batch_job_queue" "job_queue" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  name = "log-group-${local.prefix}"
+  name = "covalent-${local.prefix}-log-group"
 }
 
 resource "aws_cloudwatch_log_stream" "log_stream" {
-  name           = "log-stream-${local.prefix}"
+  name           = "covalent-${local.prefix}-log-stream"
   log_group_name = aws_cloudwatch_log_group.log_group.name
 }
 

--- a/covalent_awsbatch_plugin/assets/infra/main.tf
+++ b/covalent_awsbatch_plugin/assets/infra/main.tf
@@ -27,8 +27,7 @@ resource "random_string" "default_suffix" {
 }
 
 locals {
-  suffix = var.suffix == "" ? random_string.default_suffix.result : var.suffix
-
+  suffix    = var.suffix == "" ? random_string.default_suffix.result : var.suffix
   vpc_id    = var.vpc_id == "" ? aws_default_vpc.default.id : var.vpc_id
   subnet_id = var.subnet_id == "" ? aws_default_subnet.default.id : var.subnet_id
 }
@@ -62,6 +61,7 @@ resource "aws_batch_job_queue" "job_queue" {
   name     = "queue-${local.suffix}"
   state    = "ENABLED"
   priority = 1
+
   compute_environments = [
     aws_batch_compute_environment.compute_environment.arn
   ]

--- a/covalent_awsbatch_plugin/assets/infra/main.tf
+++ b/covalent_awsbatch_plugin/assets/infra/main.tf
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-provider "aws" {
-  region = var.aws_region
-}
+provider "aws" {}
+
+data "aws_region" "current" {}
 
 resource "random_string" "default_prefix" {
   length  = 9
@@ -25,11 +25,12 @@ resource "random_string" "default_prefix" {
 }
 
 locals {
-  prefix    = var.prefix == "" ? random_string.default_prefix.result : var.prefix
-  vpc_id    = var.vpc_id == "" ? aws_default_vpc.default.id : var.vpc_id
-  subnet_id = var.subnet_id == "" ? aws_default_subnet.default.id : var.subnet_id
+  prefix      = var.prefix == "" ? random_string.default_prefix.result : var.prefix
+  vpc_id      = var.vpc_id == "" ? aws_default_vpc.default.id : var.vpc_id
+  subnet_id   = var.subnet_id == "" ? aws_default_subnet.default.id : var.subnet_id
   credentials = var.credentials == "" ? pathexpand("~/.aws/credentials") : var.credentials
-  profile = var.profile == "" ? "default" : var.profile
+  profile     = var.profile == "" ? "default" : var.profile
+  region      = var.region == "" ? data.aws_region.current.name : var.region
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -83,7 +84,7 @@ resource "local_file" "rest_api_openapi_spec" {
   content = templatefile("${path.module}/awsbatch.conf.tftpl", {
     credentials               = local.credentials
     profile                   = local.profile
-    region                    = var.aws_region
+    region                    = local.region
     s3_bucket_name            = aws_s3_bucket.bucket.id
     batch_queue               = aws_batch_job_queue.job_queue.name
     batch_execution_role_name = aws_iam_role.ecs_tasks_execution_role.name

--- a/covalent_awsbatch_plugin/assets/infra/networking.tf
+++ b/covalent_awsbatch_plugin/assets/infra/networking.tf
@@ -1,34 +1,19 @@
-module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+resource "aws_default_vpc" "default" {}
 
-  create_vpc = (var.vpc_id == "")
-
-  name = "${var.prefix}-vpc"
-  cidr = var.vpc_cidr
-
-  azs = ["${var.aws_region}a"]
-
-  public_subnets = [
-    cidrsubnet(var.vpc_cidr, 0, 0)
-  ]
-  private_subnets = []
-
-  enable_nat_gateway   = false
-  single_nat_gateway   = false
-  enable_dns_hostnames = true
-  map_public_ip_on_launch = true
+resource "aws_default_subnet" "default" {
+  availability_zone = "${var.aws_region}${var.aws_zone}"
 }
 
 resource "aws_security_group" "sg" {
-  name = "${var.prefix}-sg"
+  name        = "${local.suffix}"
   description = "Allow traffic to Covalent server"
-  vpc_id = "${var.vpc_id == "" ? module.vpc.vpc_id : var.vpc_id}"
+  vpc_id      = local.vpc_id
 
   egress {
     description = "Allow all outbound traffic"
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/covalent_awsbatch_plugin/assets/infra/networking.tf
+++ b/covalent_awsbatch_plugin/assets/infra/networking.tf
@@ -21,7 +21,7 @@ resource "aws_default_subnet" "default" {
 }
 
 resource "aws_security_group" "sg" {
-  name        = local.suffix
+  name        = local.prefix
   description = "Allow traffic to Covalent server"
   vpc_id      = local.vpc_id
 

--- a/covalent_awsbatch_plugin/assets/infra/networking.tf
+++ b/covalent_awsbatch_plugin/assets/infra/networking.tf
@@ -21,7 +21,7 @@ resource "aws_default_subnet" "default" {
 }
 
 resource "aws_security_group" "sg" {
-  name        = local.prefix
+  name        = "covalent-${local.prefix}-sg"
   description = "Allow traffic to Covalent server"
   vpc_id      = local.vpc_id
 

--- a/covalent_awsbatch_plugin/assets/infra/networking.tf
+++ b/covalent_awsbatch_plugin/assets/infra/networking.tf
@@ -1,3 +1,19 @@
+# Copyright 2021 Agnostiq Inc.
+#
+# This file is part of Covalent.
+#
+# Licensed under the Apache License 2.0 (the "License"). A copy of the
+# License may be obtained with this software package or at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Use of this file is prohibited except in compliance with the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 resource "aws_default_vpc" "default" {}
 
 resource "aws_default_subnet" "default" {

--- a/covalent_awsbatch_plugin/assets/infra/networking.tf
+++ b/covalent_awsbatch_plugin/assets/infra/networking.tf
@@ -21,7 +21,7 @@ resource "aws_default_subnet" "default" {
 }
 
 resource "aws_security_group" "sg" {
-  name        = "${local.suffix}"
+  name        = local.suffix
   description = "Allow traffic to Covalent server"
   vpc_id      = local.vpc_id
 

--- a/covalent_awsbatch_plugin/assets/infra/networking.tf
+++ b/covalent_awsbatch_plugin/assets/infra/networking.tf
@@ -17,7 +17,7 @@
 resource "aws_default_vpc" "default" {}
 
 resource "aws_default_subnet" "default" {
-  availability_zone = "${var.aws_region}${var.aws_zone}"
+  availability_zone = "${local.region}${var.aws_zone}"
 }
 
 resource "aws_security_group" "sg" {

--- a/covalent_awsbatch_plugin/assets/infra/variables.tf
+++ b/covalent_awsbatch_plugin/assets/infra/variables.tf
@@ -72,13 +72,13 @@ variable "vpc_cidr" {
 # Executor missing configuration
 variable "credentials" {
   type        = string
-  default     = pathexpand("~/.aws/credentials")
+  default     = ""
   description = "Path to the AWS shared configuration file"
 }
 
 variable "profile" {
   type        = string
-  default     = "default"
+  default     = ""
   description = "AWS profile used during execution"
 }
 

--- a/covalent_awsbatch_plugin/assets/infra/variables.tf
+++ b/covalent_awsbatch_plugin/assets/infra/variables.tf
@@ -18,8 +18,8 @@ variable "prefix" {
   default     = ""
   description = "prefix used for the AWS Resources created for the executor"
 }
-variable "aws_region" {
-  default     = "us-east-1"
+variable "region" {
+  default     = ""
   description = "Region in which Covalent is deployed"
 }
 

--- a/covalent_awsbatch_plugin/assets/infra/variables.tf
+++ b/covalent_awsbatch_plugin/assets/infra/variables.tf
@@ -72,13 +72,13 @@ variable "vpc_cidr" {
 # Executor missing configuration
 variable "credentials" {
   type        = string
-  default     = ""
+  default     = pathexpand("~/.aws/credentials")
   description = "Path to the AWS shared configuration file"
 }
 
 variable "profile" {
   type        = string
-  default     = ""
+  default     = "default"
   description = "AWS profile used during execution"
 }
 

--- a/covalent_awsbatch_plugin/assets/infra/variables.tf
+++ b/covalent_awsbatch_plugin/assets/infra/variables.tf
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "suffix" {
+variable "prefix" {
   default     = ""
-  description = "suffix used for the AWS Resources created for the executor"
+  description = "prefix used for the AWS Resources created for the executor"
 }
 variable "aws_region" {
   default     = "us-east-1"

--- a/covalent_awsbatch_plugin/assets/infra/variables.tf
+++ b/covalent_awsbatch_plugin/assets/infra/variables.tf
@@ -14,56 +14,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "prefix" {
-  default = "covalent-batch"
-  description = "Prefix used for the AWS Resources created for the executor"
+variable "suffix" {
+  default     = ""
+  description = "suffix used for the AWS Resources created for the executor"
 }
 variable "aws_region" {
   default     = "us-east-1"
   description = "Region in which Covalent is deployed"
 }
 
+variable "aws_zone" {
+  default     = "a"
+  description = "Availability zone in which Covalent is deployed"
+}
+
 variable "vpc_id" {
-  type = string
+  type        = string
   description = "Existing VPC ID"
-  default = ""
+  default     = ""
 }
 
 variable "subnet_id" {
-  type = string
+  type        = string
   description = "Existing subnet ID"
-  default = ""
+  default     = ""
 }
 
 variable "instance_types" {
-  type = string
+  type        = string
   description = "Instance type used for Covalent"
   default     = "optimal"
 }
 
 variable "min_vcpus" {
-  type = number
+  type        = number
   description = "Minimum number of vCPUs to use for Covalent"
   default     = 0
 }
 
 variable "max_vcpus" {
-  type = number
+  type        = number
   description = "Maximum number of vCPUs to use for Covalent"
   default     = 256
 }
 
-variable "aws_s3_bucket" {
-  default     = "job-resources"
-  description = "S3 bucket used for file batch job resources"
-}
-variable "aws_batch_queue" {
-  default = "queue"
-  description = "Batch queue used for jobs"
-}
-
 variable "aws_batch_job_definition" {
-  default = "job-definition"
+  default     = "job-definition"
   description = "Batch queue used for jobs"
 }
 
@@ -74,56 +70,56 @@ variable "vpc_cidr" {
 
 
 # Executor missing configuration
-variable credentials {
-  type = string
-  default = ""
+variable "credentials" {
+  type        = string
+  default     = ""
   description = "Path to the AWS shared configuration file"
 }
 
-variable profile {
-  type = string
-  default = ""
+variable "profile" {
+  type        = string
+  default     = ""
   description = "AWS profile used during execution"
 }
 
-variable vcpus {
-  type = number
-  default = 2
+variable "vcpus" {
+  type        = number
+  default     = 2
   description = "Number of vcpus a batch job will consume by default"
 }
 
-variable memory {
-  type = number
-  default = 3.25
+variable "memory" {
+  type        = number
+  default     = 3.25
   description = "Memory in GB for the batch job"
 }
 
-variable num_gpus {
-  type = number
-  default = 0
+variable "num_gpus" {
+  type        = number
+  default     = 0
   description = "Number of GPUS required by the batch job"
 }
 
-variable retry_attempts {
-  type = number
-  default = 3
+variable "retry_attempts" {
+  type        = number
+  default     = 3
   description = "Number of retries to attempt before considering the batch job failed"
 }
 
-variable time_limit {
-  type = number
-  default = 300
+variable "time_limit" {
+  type        = number
+  default     = 300
   description = "Number of seconds before the batch job is considered to be timed out"
 }
 
-variable cache_dir {
-  type = string
-  default = "/tmp/covalent"
+variable "cache_dir" {
+  type        = string
+  default     = "/tmp/covalent"
   description = "Path on local machine where temporary files are generated"
 }
 
-variable poll_freq {
-  type = number
-  default = 5
+variable "poll_freq" {
+  type        = number
+  default     = 5
   description = "Frequency with which to poll AWS batch for the result object"
 }


### PR DESCRIPTION
### Changed

- Edit terraform scripts to require no user input in most cases (except maybe `region`).

---

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
